### PR TITLE
Enables extending the Text Formatters to allow custom logic by implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :josephcappellino: Added
+
+- [#416](https://github.com/FantasticFiasco/serilog-sinks-http/pull/416) Updates `NormalTextFormatter` to have virtual methods for each field so child implementations can override specific fields instead of requiring the duplication of the entire class. Additionally, `CompactTextFormatter` and `NamespacedTextFormatter` now extend `NormalTextFormatter` to provide a common framework for the text formatters, as well as default logic for most fields.
+
 ## [9.1.0] - 2025-01-19
 
 ### :zap: Added

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
@@ -50,27 +50,24 @@ public class CompactTextFormatter : NormalTextFormatter
         RenderingsTag = "@r";
     }
 
-    /// <summary>
-    /// Writes the Trace ID to the output.
-    /// </summary>
-    /// <param name="logEvent">The event to format.</param>
-    /// <param name="output">The output.</param>
+    /// <inheritdoc />
+    protected override void WriteLogLevel(LogEvent logEvent, TextWriter output)
+    {
+        if (logEvent.Level != LogEventLevel.Information)
+        {
+            base.WriteLogLevel(logEvent, output);
+        }
+    }
+
+    /// <inheritdoc />
     protected override void WriteTraceId(LogEvent logEvent, TextWriter output) =>
         Write(TraceIdTag, logEvent.TraceId?.ToHexString() ?? "", output);
 
-    /// <summary>
-    /// Writes the Span ID to the output.
-    /// </summary>
-    /// <param name="logEvent">The event to format.</param>
-    /// <param name="output">The output.</param>
+    /// <inheritdoc />
     protected override void WriteSpanId(LogEvent logEvent, TextWriter output) =>
         Write(SpanIdTag, logEvent.SpanId?.ToHexString() ?? "", output);
 
-    /// <summary>
-    /// Writes the collection of properties to the output.
-    /// </summary>
-    /// <param name="properties">The collection of log properties.</param>
-    /// <param name="output">The output.</param>
+    /// <inheritdoc />
     protected override void WriteProperties(
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
@@ -91,12 +88,7 @@ public class CompactTextFormatter : NormalTextFormatter
         }
     }
 
-    /// <summary>
-    /// Writes the items with rendering formats to the output.
-    /// </summary>
-    /// <param name="tokensWithFormat">The collection of tokens that have formats.</param>
-    /// <param name="properties">The collection of properties to fill the tokens.</param>
-    /// <param name="output">The output.</param>
+    /// <inheritdoc />
     protected override void WriteRenderings(
         IEnumerable<PropertyToken> tokensWithFormat,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NamespacedTextFormatter.cs
@@ -16,10 +16,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Formatting.Json;
 using Serilog.Parsing;
 
 namespace Serilog.Sinks.Http.TextFormatters;
@@ -35,10 +33,12 @@ namespace Serilog.Sinks.Http.TextFormatters;
 /// <seealso cref="CompactTextFormatter" />
 /// <seealso cref="CompactRenderedTextFormatter" />
 /// <seealso cref="ITextFormatter" />
-public abstract class NamespacedTextFormatter : ITextFormatter
+public abstract class NamespacedTextFormatter : NormalTextFormatter
 {
     private readonly string component;
     private readonly string? subComponent;
+
+    private bool isWritingProperties = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NamespacedTextFormatter"/> class.
@@ -58,107 +58,36 @@ public abstract class NamespacedTextFormatter : ITextFormatter
     {
         this.component = component ?? throw new ArgumentNullException(nameof(component));
         this.subComponent = subComponent;
+        IsRenderingMessage = true;
     }
 
-    /// <summary>
-    /// Gets or sets a value indicating whether the message is rendered into JSON. Default
-    /// value is <see langword="true"/>.
-    /// </summary>
-    protected bool IsRenderingMessage { get; set; } = true;
-
-    /// <summary>
-    /// Format the log event into the output.
-    /// </summary>
-    /// <param name="logEvent">The event to format.</param>
-    /// <param name="output">The output.</param>
-    public void Format(LogEvent logEvent, TextWriter output)
+    /// <inheritdoc />
+    protected override void WriteProperties(LogEvent logEvent, TextWriter output)
     {
-        try
-        {
-            var buffer = new StringWriter();
-            FormatContent(logEvent, buffer);
-
-            // If formatting was successful, write to output
-            output.WriteLine(buffer.ToString());
-        }
-        catch (Exception e)
-        {
-            LogNonFormattableEvent(logEvent, e);
-        }
-    }
-
-    private void FormatContent(LogEvent logEvent, TextWriter output)
-    {
-        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-        if (output == null) throw new ArgumentNullException(nameof(output));
-
-        output.Write("{\"Timestamp\":\"");
-        output.Write(logEvent.Timestamp.UtcDateTime.ToString("o"));
-
-        output.Write("\",\"Level\":\"");
-        output.Write(logEvent.Level);
-
-        output.Write("\",\"MessageTemplate\":");
-        JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
-
-        if (IsRenderingMessage)
-        {
-            output.Write(",\"RenderedMessage\":");
-
-            var message = logEvent.MessageTemplate.Render(logEvent.Properties);
-            JsonValueFormatter.WriteQuotedJsonString(message, output);
-        }
-
-        if (logEvent.Exception != null)
-        {
-            output.Write(",\"Exception\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
-        }
-
-        if (logEvent.TraceId != null)
-        {
-            output.Write(",\"TraceId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.TraceId.ToString()!, output);
-        }
-
-        if (logEvent.SpanId != null)
-        {
-            output.Write(",\"SpanId\":");
-            JsonValueFormatter.WriteQuotedJsonString(logEvent.SpanId.ToString()!, output);
-        }
-
-        if (logEvent.Properties.Count != 0)
-        {
-            WriteProperties(logEvent, output);
-        }
-
-        output.Write('}');
-    }
-
-    private void WriteProperties(LogEvent logEvent, TextWriter output)
-    {
+        isWritingProperties = true;
         output.Write(",\"Properties\":{");
 
         var messageTemplateProperties = logEvent.Properties
-            .Where(property => TemplateContainsPropertyName(logEvent.MessageTemplate, property.Key))
-            .ToArray();
+            .Where(property => logEvent.MessageTemplate.Tokens
+                .Where(token => token is PropertyToken namedToken && namedToken.PropertyName == property.Key)
+                .Any()
+            )
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        if (messageTemplateProperties.Length > 0)
+        if (messageTemplateProperties.Count > 0)
         {
             WriteOpenNamespace(output);
 
-            WriteProperties(messageTemplateProperties, output);
+            WritePropertiesValues(messageTemplateProperties, output);
 
             // Better not to allocate an array in the 99.9% of cases where this is false
-            var tokensWithFormat = logEvent.MessageTemplate.Tokens
-                .OfType<PropertyToken>()
-                .Where(propertyToken => propertyToken.Format != null);
+            var tokensWithFormat = GetTokensWithFormat(logEvent);
 
             // ReSharper disable once PossibleMultipleEnumeration
             if (tokensWithFormat.Any())
             {
                 // ReSharper disable once PossibleMultipleEnumeration
-                WriteRenderings(tokensWithFormat.GroupBy(pt => pt.PropertyName), logEvent.Properties, output);
+                WriteRenderings(tokensWithFormat, logEvent.Properties, output);
             }
 
             WriteCloseNamespace(output);
@@ -166,19 +95,20 @@ public abstract class NamespacedTextFormatter : ITextFormatter
 
         var enrichedProperties = logEvent.Properties
             .Except(messageTemplateProperties)
-            .ToArray();
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-        if (enrichedProperties.Length > 0)
+        if (enrichedProperties.Count > 0)
         {
-            if (messageTemplateProperties.Length > 0)
+            if (messageTemplateProperties.Count > 0)
             {
                 output.Write(",");
             }
 
-            WriteProperties(enrichedProperties, output);
+            WritePropertiesValues(enrichedProperties, output);
         }
 
         output.Write('}');
+        isWritingProperties = false;
     }
 
     private void WriteOpenNamespace(TextWriter output)
@@ -195,79 +125,17 @@ public abstract class NamespacedTextFormatter : ITextFormatter
             : "}");
     }
 
-    private static void WriteProperties(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties, TextWriter output)
-    {
-        var precedingDelimiter = string.Empty;
-
-        foreach (var property in properties)
-        {
-            output.Write(precedingDelimiter);
-            precedingDelimiter = ",";
-
-            JsonValueFormatter.WriteQuotedJsonString(property.Key, output);
-            output.Write(':');
-            ValueFormatter.Instance.Format(property.Value, output);
-        }
-    }
-
-    private static bool TemplateContainsPropertyName(MessageTemplate template, string propertyName)
-    {
-        foreach (var token in template.Tokens)
-        {
-            if (token is PropertyToken namedProperty
-                && namedProperty.PropertyName == propertyName)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static void WriteRenderings(
-        IEnumerable<IGrouping<string, PropertyToken>> tokensWithFormat,
+    /// <inheritdoc />
+    protected override void WriteRenderings(
+        IEnumerable<IGrouping<string, PropertyToken>> tokensGrouped,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"Renderings\":{");
-
-        var rdelim = string.Empty;
-        foreach (var ptoken in tokensWithFormat)
+        // Only write the renderings during the properties phase as they need to be
+        // encapsulated with the namespace
+        if (isWritingProperties)
         {
-            output.Write(rdelim);
-            rdelim = ",";
-
-            JsonValueFormatter.WriteQuotedJsonString(ptoken.Key, output);
-            output.Write(":[");
-
-            var fdelim = string.Empty;
-            foreach (var format in ptoken)
-            {
-                output.Write(fdelim);
-                fdelim = ",";
-
-                output.Write("{\"Format\":");
-                JsonValueFormatter.WriteQuotedJsonString(format.Format ?? "\"\"", output);
-
-                output.Write(",\"Rendering\":");
-                var sw = new StringWriter();
-                format.Render(properties, sw);
-                JsonValueFormatter.WriteQuotedJsonString(sw.ToString(), output);
-                output.Write('}');
-            }
-
-            output.Write(']');
+            base.WriteRenderings(tokensGrouped, properties, output);
         }
-
-        output.Write('}');
-    }
-
-    private static void LogNonFormattableEvent(LogEvent logEvent, Exception e)
-    {
-        SelfLog.WriteLine(
-            "Event at {0} with message template {1} could not be formatted into JSON and will be dropped: {2}",
-            logEvent.Timestamp.ToString("o"),
-            logEvent.MessageTemplate.Text,
-            e);
     }
 }

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -190,7 +190,7 @@ public class NormalTextFormatter : ITextFormatter
         if (tokensWithFormat.Any())
         {
             // ReSharper disable once PossibleMultipleEnumeration
-            WriteRenderings(tokensWithFormat.GroupBy(pt => pt.PropertyName), logEvent.Properties, output);
+            WriteRenderings(tokensWithFormat, logEvent.Properties, output);
         }
 
         output.Write('}');
@@ -287,16 +287,17 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="properties">The collection of properties to fill the tokens.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteRenderings(
-        IEnumerable<IGrouping<string, PropertyToken>> tokensWithFormat,
+        IEnumerable<PropertyToken> tokensWithFormat,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
+        var tokensGrouped = tokensWithFormat.GroupBy(pt => pt.PropertyName);
         output.Write(",\"");
         output.Write(RenderingsTag);
         output.Write("\":{");
 
         var rdelim = string.Empty;
-        foreach (var ptoken in tokensWithFormat)
+        foreach (var ptoken in tokensGrouped)
         {
             output.Write(rdelim);
             rdelim = ",";

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2025 Serilog Contributors
+// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ public class NormalTextFormatter : ITextFormatter
 
         if (logEvent.Properties.Count != 0)
         {
-            WriteProperties(logEvent.Properties, output);
+            WriteProperties(logEvent, output);
         }
 
         // Better not to allocate an array in the 99.9% of cases where this is false

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -182,9 +182,7 @@ public class NormalTextFormatter : ITextFormatter
         }
 
         // Better not to allocate an array in the 99.9% of cases where this is false
-        var tokensWithFormat = logEvent.MessageTemplate.Tokens
-            .OfType<PropertyToken>()
-            .Where(pt => pt.Format != null);
+        var tokensWithFormat = GetTokensWithFormat(logEvent);
 
         // ReSharper disable once PossibleMultipleEnumeration
         if (tokensWithFormat.Any())
@@ -195,6 +193,16 @@ public class NormalTextFormatter : ITextFormatter
 
         output.Write('}');
     }
+
+    /// <summary>
+    /// Gets the collection of tokens with formatting.
+    /// </summary>
+    /// <param name="logEvent">The log event.</param>
+    /// <returns>The collection of found tokens.</returns>
+    protected virtual IEnumerable<PropertyToken> GetTokensWithFormat(LogEvent logEvent) =>
+        logEvent.MessageTemplate.Tokens
+            .OfType<PropertyToken>()
+            .Where(pt => pt.Format != null);
 
     /// <summary>
     /// Writes the timestamp in UTC format to the output.
@@ -251,6 +259,14 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="output">The output.</param>
     protected virtual void WriteSpanId(LogEvent logEvent, TextWriter output) =>
         Write(SpanIdTag, logEvent.SpanId?.ToString() ?? "", output);
+
+    /// <summary>
+    /// Writes the collection of properties to the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    protected virtual void WriteProperties(LogEvent logEvent, TextWriter output) =>
+        WriteProperties(logEvent.Properties, output);
 
     /// <summary>
     /// Writes the collection of properties to the output.

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -123,7 +123,12 @@ public class NormalTextFormatter : ITextFormatter
         output.Write('}');
     }
 
-    private static void WriteProperties(
+    /// <summary>
+    /// Writes the collection of properties to the output.
+    /// </summary>
+    /// <param name="properties">The collection of log properties.</param>
+    /// <param name="output">The output.</param>
+    protected virtual void WriteProperties(
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
@@ -144,7 +149,13 @@ public class NormalTextFormatter : ITextFormatter
         output.Write('}');
     }
 
-    private static void WriteRenderings(
+    /// <summary>
+    /// Writes the items with rendering formats to the output.
+    /// </summary>
+    /// <param name="tokensWithFormat">The collection of tokens that have formats.</param>
+    /// <param name="properties">The collection of properties to fill the tokens.</param>
+    /// <param name="output">The output.</param>
+    protected virtual void WriteRenderings(
         IEnumerable<IGrouping<string, PropertyToken>> tokensWithFormat,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 Serilog Contributors
+﻿// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -281,6 +281,20 @@ public class NormalTextFormatter : ITextFormatter
         output.Write(PropertiesTag);
         output.Write("\":{");
 
+        WritePropertiesValues(properties, output);
+
+        output.Write('}');
+    }
+
+    /// <summary>
+    /// Writes the collection of properties to the output without the wrapped tag.
+    /// </summary>
+    /// <param name="properties">The collection of log properties.</param>
+    /// <param name="output">The output.</param>
+    protected virtual void WritePropertiesValues(
+        IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+        TextWriter output)
+    {
         var precedingDelimiter = string.Empty;
 
         foreach (var property in properties)
@@ -292,8 +306,6 @@ public class NormalTextFormatter : ITextFormatter
             output.Write(':');
             ValueFormatter.Instance.Format(property.Value, output);
         }
-
-        output.Write('}');
     }
 
     /// <summary>

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -48,6 +48,61 @@ public class NormalTextFormatter : ITextFormatter
     private bool hasTags = false;
 
     /// <summary>
+    /// The output for the Timestamp Tag.
+    /// </summary>
+    protected string TimestampTag { get; set; } = "Timestamp";
+
+    /// <summary>
+    /// The output for the Log Level Tag.
+    /// </summary>
+    protected string LogLevelTag { get; set; } = "Level";
+
+    /// <summary>
+    /// The output for the Message Template Tag.
+    /// </summary>
+    protected string MessageTemplateTag { get; set; } = "MessageTemplate";
+
+    /// <summary>
+    /// The output for the Rendered Message Tag.
+    /// </summary>
+    protected string RenderedMessageTag { get; set; } = "RenderedMessage";
+
+    /// <summary>
+    /// The output for the Exception Tag.
+    /// </summary>
+    protected string ExceptionTag { get; set; } = "Exception";
+
+    /// <summary>
+    /// The output for the Trace ID Tag.
+    /// </summary>
+    protected string TraceIdTag { get; set; } = "TraceId";
+
+    /// <summary>
+    /// The output for the Span ID Tag.
+    /// </summary>
+    protected string SpanIdTag { get; set; } = "SpanId";
+
+    /// <summary>
+    /// The output for the Properties Tag.
+    /// </summary>
+    protected string PropertiesTag { get; set; } = "Properties";
+
+    /// <summary>
+    /// The output for the Renderings Tag.
+    /// </summary>
+    protected string RenderingsTag { get; set; } = "Renderings";
+
+    /// <summary>
+    /// The output for the Renderings Format Tag.
+    /// </summary>
+    protected string RenderingsFormatTag { get; set; } = "Format";
+
+    /// <summary>
+    /// The output for the Renderings Rendering Tag.
+    /// </summary>
+    protected string RenderingsRenderingTag { get; set; } = "Rendering";
+
+    /// <summary>
     /// Writes the tag and value to the output.
     /// </summary>
     /// <param name="tag">The JSON Tag.</param>
@@ -147,7 +202,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteTimestamp(LogEvent logEvent, TextWriter output) =>
-        Write("Timestamp", logEvent.Timestamp.UtcDateTime.ToString("O"), output);
+        Write(TimestampTag, logEvent.Timestamp.UtcDateTime.ToString("O"), output);
 
     /// <summary>
     /// Writes the log level to the output.
@@ -155,7 +210,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteLogLevel(LogEvent logEvent, TextWriter output) =>
-        Write("Level", logEvent.Level.ToString(), output);
+        Write(LogLevelTag, logEvent.Level.ToString(), output);
 
     /// <summary>
     /// Writes the message template to the output.
@@ -163,7 +218,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteMessageTemplate(LogEvent logEvent, TextWriter output) =>
-        Write("MessageTemplate", logEvent.MessageTemplate.Text, output);
+        Write(MessageTemplateTag, logEvent.MessageTemplate.Text, output);
 
     /// <summary>
     /// Writes the rendered message to the output.
@@ -171,7 +226,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteRenderedMessage(LogEvent logEvent, TextWriter output) =>
-        Write("RenderedMessage", logEvent.MessageTemplate.Render(logEvent.Properties), output);
+        Write(RenderedMessageTag, logEvent.MessageTemplate.Render(logEvent.Properties), output);
 
     /// <summary>
     /// Writes the exception to the output.
@@ -179,7 +234,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteException(LogEvent logEvent, TextWriter output) =>
-        Write("Exception", logEvent.Exception?.ToString() ?? "", output);
+        Write(ExceptionTag, logEvent.Exception?.ToString() ?? "", output);
 
     /// <summary>
     /// Writes the Trace ID to the output.
@@ -187,7 +242,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteTraceId(LogEvent logEvent, TextWriter output) =>
-        Write("TraceId", logEvent.TraceId?.ToString() ?? "", output);
+        Write(TraceIdTag, logEvent.TraceId?.ToString() ?? "", output);
 
     /// <summary>
     /// Writes the Span ID to the output.
@@ -195,7 +250,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteSpanId(LogEvent logEvent, TextWriter output) =>
-        Write("SpanId", logEvent.SpanId?.ToString() ?? "", output);
+        Write(SpanIdTag, logEvent.SpanId?.ToString() ?? "", output);
 
     /// <summary>
     /// Writes the collection of properties to the output.
@@ -206,7 +261,9 @@ public class NormalTextFormatter : ITextFormatter
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"Properties\":{");
+        output.Write(",\"");
+        output.Write(PropertiesTag);
+        output.Write("\":{");
 
         var precedingDelimiter = string.Empty;
 
@@ -234,7 +291,9 @@ public class NormalTextFormatter : ITextFormatter
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"Renderings\":{");
+        output.Write(",\"");
+        output.Write(RenderingsTag);
+        output.Write("\":{");
 
         var rdelim = string.Empty;
         foreach (var ptoken in tokensWithFormat)
@@ -251,10 +310,14 @@ public class NormalTextFormatter : ITextFormatter
                 output.Write(fdelim);
                 fdelim = ",";
 
-                output.Write("{\"Format\":");
+                output.Write("{\"");
+                output.Write(RenderingsFormatTag);
+                output.Write("\":");
                 JsonValueFormatter.WriteQuotedJsonString(format.Format ?? "\"\"", output);
 
-                output.Write(",\"Rendering\":");
+                output.Write(",\"");
+                output.Write(RenderingsRenderingTag);
+                output.Write("\":");
                 var sw = new StringWriter();
                 format.Render(properties, sw);
                 JsonValueFormatter.WriteQuotedJsonString(sw.ToString(), output);

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -305,9 +305,20 @@ public class NormalTextFormatter : ITextFormatter
     protected virtual void WriteRenderings(
         IEnumerable<PropertyToken> tokensWithFormat,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+        TextWriter output) =>
+            WriteRenderings(tokensWithFormat.GroupBy(pt => pt.PropertyName), properties, output);
+
+    /// <summary>
+    /// Writes the items with rendering formats to the output.
+    /// </summary>
+    /// <param name="tokensGrouped">The collection of tokens that have formats, grouped by property name.</param>
+    /// <param name="properties">The collection of properties to fill the tokens.</param>
+    /// <param name="output">The output.</param>
+    protected virtual void WriteRenderings(
+        IEnumerable<IGrouping<string, PropertyToken>> tokensGrouped,
+        IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        var tokensGrouped = tokensWithFormat.GroupBy(pt => pt.PropertyName);
         output.Write(",\"");
         output.Write(RenderingsTag);
         output.Write("\":{");


### PR DESCRIPTION
# Description

We have recently created a helper library that provides a common implementation of the Serilog interface. Unfortunately, it required a slight modification to the output JSON to be compatible with the downstream usage (hopefully, to be fixed in the future).

The current framework allows providing a custom `ITextFormatter` during initialization. In my case, we want the standard logic for all fields _except_ `Properties`. This would require duplicating the entire class which could go out of sync with the existing framework.

These changes update the `NormalTextFormatter` class to be the base class for `CompactTextFormatter` and `NamespacedTextFormatter` implementations. This provides a common workflow for all implementations, as well as virtual methods that allow overriding any differences in the flow.

Another benefit to these changes is to keep the different formatters in sync, as they all should have very similar workflows and support the same top-level fields.

# Checklist

- [ :white_check_mark: ] My code follows the style guidelines of this project
- [ :white_check_mark: ] I have performed a self-review of my own code
- [ :white_check_mark: ] I have commented my code, particularly in hard-to-understand areas
- [ :white_check_mark: ] I have made corresponding changes to the documentation
- [ :white_check_mark: ] I have added tests that prove my fix is effective or that my feature works
   > I did not add any _new_ tests, but I also did not change any logic other than providing extension methods. The existing tests have covered all my changes.
