### PR TITLE
ENH: Updates links to use HTTPS and updates `REAMDE.md` to show differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-This project adheres to [Semantic Versioning](http://semver.org/) and is following the [change log format](http://keepachangelog.com/).
+This project adheres to [Semantic Versioning](https://semver.org/) and is following the [change log format](https://keepachangelog.com/).
 
 ## Unreleased
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![CI/CD](https://github.com/josephcappellino/serilog-sinks-http/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/josephcappellino/serilog-sinks-http/actions/workflows/ci-cd.yml)
 [![codecov](https://codecov.io/gh/FantasticFiasco/serilog-sinks-http/branch/main/graph/badge.svg?token=cw6OYeQmdH)](https://codecov.io/gh/FantasticFiasco/serilog-sinks-http)
-[![NuGet Version](http://img.shields.io/nuget/v/Serilog.Sinks.Http.Extensible.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.Http.Extensible/)
+[![NuGet Version](https://img.shields.io/nuget/v/Serilog.Sinks.Http.Extensible.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.Http.Extensible/)
 [![SemVer compatible](https://img.shields.io/badge/%E2%9C%85-SemVer%20compatible-blue)](https://semver.org/)
 [![NuGet](https://img.shields.io/nuget/dt/Serilog.Sinks.Http.Extensible.svg)](https://www.nuget.org/packages/Serilog.Sinks.Http.Extensible/)
 [![Documentation](https://img.shields.io/badge/docs-wiki-yellow.svg)](https://github.com/serilog/serilog/wiki)
 [![Join the chat at https://gitter.im/serilog/serilog](https://img.shields.io/gitter/room/serilog/serilog.svg)](https://gitter.im/serilog/serilog)
-[![Help](https://img.shields.io/badge/stackoverflow-serilog-orange.svg)](http://stackoverflow.com/questions/tagged/serilog)
+[![Help](https://img.shields.io/badge/stackoverflow-serilog-orange.svg)](https://stackoverflow.com/questions/tagged/serilog)
 
 **Package** - [Serilog.Sinks.Http.Extensible](https://www.nuget.org/packages/serilog.sinks.http.extensible) | **Platforms** - .NET 4.5/4.6.1, .NET Standard 2.0/2.1
 
@@ -35,7 +35,7 @@ And here we are today. I hope you'll find the sink useful. If not, don't hesitat
 
 ## Super simple to use
 
-In the following example, the sink will POST log events to `http://www.mylogs.com` over HTTP. We configure the sink using **[named arguments](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments) instead of positional** because historically we've seen that most breaking changes where the result of a new parameter describing a new feature. Using named arguments means that you more often than not can migrate to new major versions without any changes to your code.
+In the following example, the sink will POST log events to `https://www.mylogs.com` over HTTP. We configure the sink using **[named arguments](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments) instead of positional** because historically we've seen that most breaking changes where the result of a new parameter describing a new feature. Using named arguments means that you more often than not can migrate to new major versions without any changes to your code.
 
 ```csharp
 ILogger log = new LoggerConfiguration()

--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@
 
 **Package** - [Serilog.Sinks.Http.Extensible](https://www.nuget.org/packages/serilog.sinks.http.extensible) | **Platforms** - .NET 4.5/4.6.1, .NET Standard 2.0/2.1
 
+> [!NOTE]
+> See [Differences from base package `Serilog.Sinks.Http`](#differences-from-base-package-serilogsinkshttp) for what makes this repository/package different from the base package.
+
 ## Table of contents <!-- omit in toc -->
 
 - [Introduction](#introduction)
+- [Differences from base package `Serilog.Sinks.Http`](#differences-from-base-package-serilogsinkshttp)
+  - [`ITextFormatter` Implementations](#itextformatter-implementations)
 - [Super simple to use](#super-simple-to-use)
 - [Typical use cases](#typical-use-cases)
   - [Send log events from Docker containers](#send-log-events-from-docker-containers)
@@ -32,6 +37,16 @@ This project started out with a wish to send log events to the Elastic Stack. I 
 Knowing that [Serilog.Sinks.Seq](https://github.com/serilog/serilog-sinks-seq) existed, and knowing that the code was of really good quality, I blatantly copied many of the core files into this project and started developing a general HTTP sink.
 
 And here we are today. I hope you'll find the sink useful. If not, don't hesitate to open an issue.
+
+## Differences from base package `Serilog.Sinks.Http`
+
+This repo was forked from [FantasticFiasco](https://github.com/FantasticFiasco)'s [Serilog.Sinks.Http](https://github.com/FantasticFiasco/serilog-sinks-http).
+
+This repository was created to provide additional extensibility to Text Formatters, but could be used to further the development of the Sink.
+
+### `ITextFormatter` Implementations
+
+There was a need to provide extensibility to the Text Formatters as to not have to duplicate the entire formatter to change a small portion. To handle this, [`NormalTextFormatter`](./src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs) became the base class for all other implementations and provided `protected virtual` methods/properties for each output field. This then allows child classes to override just the methods they need different from the base implementation. This design was carried out and used for `CompactTextFormatter` (with the use of overriding field names, as well as values) and `NamespacedTextFormatter` (which overrides the `Properties` field while also calling the base implementation to loop around the data).
 
 ## Super simple to use
 


### PR DESCRIPTION
# Description

After uploading to NuGet.org, there were warnings regarding insecure links. These were updated to use `https`.

This also updates the `README.md` to include differences between this repo and the base repo.
