### PR TITLE
BUG: Fixes concurrency issue due to singleton instance of text formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/) and is follow
 
 ## Unreleased
 
+## [9.2.3] - 2025-03-05
+
+### :zap: Added
+
+- [#10] - Fixes concurrency issue where processing multiple log entries at the same time would generate invalid JSON.
+
 ## [9.2.2] - 2025-02-21
 
 ### :zap: Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VersionPrefix>9.2.2</VersionPrefix>
+    <VersionPrefix>9.2.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Mattias Kindborg</Authors>
     <Copyright>Copyright 2015-2025 Serilog Contributors</Copyright>

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2025 Serilog Contributors
+// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.Http.Private.IO;
+using Serilog.Sinks.Http.TextFormatters;
 
 namespace Serilog.Sinks.Http.Private.Durable;
 
@@ -56,7 +57,7 @@ public class FileSizeRolledDurableHttpSink : ILogEventSink, IDisposable
             bufferFileSizeLimitBytes,
             bufferFileShared,
             retainedBufferFileCountLimit,
-            textFormatter);
+            new FileTextFormatter(textFormatter));
     }
 
     public void Emit(LogEvent logEvent)

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/FileSizeRolledDurableHttpSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 Serilog Contributors
+﻿// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,8 +67,17 @@ public class FileSizeRolledDurableHttpSink : ILogEventSink, IDisposable
 
     public void Dispose()
     {
-        (sink as IDisposable)?.Dispose();
-        shipper.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            (sink as IDisposable)?.Dispose();
+            shipper.Dispose();
+        }
     }
 
     private static ILogEventSink CreateFileSink(

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 Serilog Contributors
+﻿// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,8 +69,17 @@ public class TimeRolledDurableHttpSink : ILogEventSink, IDisposable
 
     public void Dispose()
     {
-        (sink as IDisposable)?.Dispose();
-        shipper.Dispose();
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            (sink as IDisposable)?.Dispose();
+            shipper.Dispose();
+        }
     }
 
     private static ILogEventSink CreateFileSink(

--- a/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/Private/Durable/TimeRolledDurableHttpSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2025 Serilog Contributors
+// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.Http.Private.IO;
+using Serilog.Sinks.Http.TextFormatters;
 
 namespace Serilog.Sinks.Http.Private.Durable;
 
@@ -58,7 +59,7 @@ public class TimeRolledDurableHttpSink : ILogEventSink, IDisposable
             bufferFileSizeLimitBytes,
             bufferFileShared,
             retainedBufferFileCountLimit,
-            textFormatter);
+            new FileTextFormatter(textFormatter));
     }
 
     public void Emit(LogEvent logEvent)

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
@@ -83,6 +83,18 @@ public class CompactTextFormatter : NormalTextFormatter
     }
 
     /// <inheritdoc />
+    protected override void WriteProperties(
+        IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+        TextWriter output)
+    {
+        foreach (var property in properties)
+        {
+            output.Write(",");
+            WritePropertyValue(property.Key, property.Value, output);
+        }
+    }
+
+    /// <inheritdoc />
     protected override void WriteRenderings(
         IEnumerable<PropertyToken> tokensWithFormat,
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
@@ -68,24 +68,18 @@ public class CompactTextFormatter : NormalTextFormatter
         Write(SpanIdKey, logEvent.SpanId?.ToHexString() ?? "", output);
 
     /// <inheritdoc />
-    protected override void WriteProperties(
-        IReadOnlyDictionary<string, LogEventPropertyValue> properties,
+    protected override void WritePropertyValue(
+        string key,
+        LogEventPropertyValue value,
         TextWriter output)
     {
-        foreach (var property in properties)
+        if (key.Length > 0 && key[0] == '@')
         {
-            var name = property.Key;
-            if (name.Length > 0 && name[0] == '@')
-            {
-                // Escape first '@' by doubling
-                name = '@' + name;
-            }
-
-            output.Write(',');
-            JsonValueFormatter.WriteQuotedJsonString(name, output);
-            output.Write(':');
-            ValueFormatter.Instance.Format(property.Value, output);
+            // Escape first '@' by doubling
+            key = '@' + key;
         }
+
+        base.WritePropertyValue(key, value, output);
     }
 
     /// <inheritdoc />

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/CompactTextFormatter.cs
@@ -89,7 +89,7 @@ public class CompactTextFormatter : NormalTextFormatter
     {
         foreach (var property in properties)
         {
-            output.Write(",");
+            output.Write(DELIMITER);
             WritePropertyValue(property.Key, property.Value, output);
         }
     }
@@ -100,14 +100,15 @@ public class CompactTextFormatter : NormalTextFormatter
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"");
-        output.Write(RenderingsKey);
-        output.Write("\":[");
+        output.Write(DELIMITER);
+        JsonValueFormatter.WriteQuotedJsonString(RenderingsKey, output);
+        output.Write(SEPARATOR);
+        output.Write("[");
         var delim = string.Empty;
         foreach (var r in tokensWithFormat)
         {
             output.Write(delim);
-            delim = ",";
+            delim = DELIMITER;
             var space = new StringWriter();
             r.Render(properties, space);
             JsonValueFormatter.WriteQuotedJsonString(space.ToString(), output);

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/FileTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/FileTextFormatter.cs
@@ -1,0 +1,63 @@
+// Copyright 2015-2025 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.Http.TextFormatters;
+
+/// <summary>
+/// This is a wrapper around the passed in <see cref="ITextFormatter"/>. This will ensure
+/// that the log event is formatted and written to the output if the formatting was successful.
+/// The main point here is that each entry is written to the output on a new line.
+/// </summary>
+/// <seealso cref="ITextFormatter" />
+public class FileTextFormatter : ITextFormatter
+{
+    private readonly ITextFormatter _textFormatter;
+
+    /// <summary>
+    /// Default Constructor used to setup the file formatter.
+    /// </summary>
+    /// <param name="textFormatter"></param>
+    public FileTextFormatter(ITextFormatter textFormatter)
+    {
+        _textFormatter = textFormatter;
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        var buffer = new StringWriter();
+        _textFormatter.Format(logEvent, buffer);
+
+        var logEntry = buffer.ToString();
+
+        // If formatting was successful, write to output
+        if (logEntry.Length > 0)
+        {
+            output.Write(logEntry);
+            if (!logEntry.EndsWith(Environment.NewLine))
+            {
+                output.WriteLine();
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -117,7 +117,7 @@ public class NormalTextFormatter : ITextFormatter
             FormatContent(logEvent, buffer);
 
             // If formatting was successful, write to output
-            output.WriteLine(buffer.ToString());
+            output.Write(buffer.ToString());
         }
         catch (Exception e)
         {

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2015-2025 Serilog Contributors
+// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,16 @@ namespace Serilog.Sinks.Http.TextFormatters;
 /// <seealso cref="ITextFormatter" />
 public class NormalTextFormatter : ITextFormatter
 {
+    /// <summary>
+    /// The delimiter used between fields.
+    /// </summary>
+    public const string DELIMITER = ",";
+
+    /// <summary>
+    /// The separator between keys and values.
+    /// </summary>
+    public const string SEPARATOR = ":";
+
     /// <summary>
     /// Gets or sets a value indicating whether the message is rendered into JSON.
     /// </summary>
@@ -124,13 +134,13 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="key">The JSON key.</param>
     /// <param name="value">The JSON value.</param>
     /// <param name="output">The output.</param>
-    /// <param name="delimStart">The preceding delimiter</param>
-    protected static void Write(string key, string value, TextWriter output, string delimStart = ",")
+    /// <param name="delimStart">The preceding delimiter.</param>
+    protected static void Write(string key, string value, TextWriter output, string delimStart = DELIMITER)
     {
         output.Write(delimStart);
 
         JsonValueFormatter.WriteQuotedJsonString(key, output);
-        output.Write(":");
+        output.Write(SEPARATOR);
         JsonValueFormatter.WriteQuotedJsonString(value, output);
     }
 
@@ -190,7 +200,7 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     protected virtual void WriteTimestamp(LogEvent logEvent, TextWriter output) =>
-        Write(TimestampKey, logEvent.Timestamp.UtcDateTime.ToString("O"), output);
+        Write(TimestampKey, logEvent.Timestamp.UtcDateTime.ToString("O"), output, string.Empty);
 
     /// <summary>
     /// Writes the log level to the output.

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -38,11 +38,6 @@ namespace Serilog.Sinks.Http.TextFormatters;
 public class NormalTextFormatter : ITextFormatter
 {
     /// <summary>
-    /// The delimiter used to start events 2+.
-    /// </summary>
-    private string delimStart = string.Empty;
-
-    /// <summary>
     /// Gets or sets a value indicating whether the message is rendered into JSON.
     /// </summary>
     protected bool IsRenderingMessage { get; set; }
@@ -129,15 +124,14 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="key">The JSON key.</param>
     /// <param name="value">The JSON value.</param>
     /// <param name="output">The output.</param>
-    protected void Write(string key, string value, TextWriter output)
+    /// <param name="delimStart">The preceding delimiter</param>
+    protected static void Write(string key, string value, TextWriter output, string delimStart = ",")
     {
         output.Write(delimStart);
 
         JsonValueFormatter.WriteQuotedJsonString(key, output);
         output.Write(":");
         JsonValueFormatter.WriteQuotedJsonString(value, output);
-
-        delimStart = ",";
     }
 
     private void FormatContent(LogEvent logEvent, TextWriter output)
@@ -145,9 +139,9 @@ public class NormalTextFormatter : ITextFormatter
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
         if (output == null) throw new ArgumentNullException(nameof(output));
 
-        delimStart = string.Empty; // force reset
         output.Write("{");
 
+        // Timestamp must be first as it does not have a preceding delimiter
         WriteTimestamp(logEvent, output);
         WriteLogLevel(logEvent, output);
         WriteMessageTemplate(logEvent, output);

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -111,8 +111,6 @@ public class NormalTextFormatter : ITextFormatter
     {
         try
         {
-            delimStart = string.Empty; // force reset
-
             var buffer = new StringWriter();
             FormatContent(logEvent, buffer);
 
@@ -147,6 +145,7 @@ public class NormalTextFormatter : ITextFormatter
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
         if (output == null) throw new ArgumentNullException(nameof(output));
 
+        delimStart = string.Empty; // force reset
         output.Write("{");
 
         WriteTimestamp(logEvent, output);

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -38,9 +38,9 @@ namespace Serilog.Sinks.Http.TextFormatters;
 public class NormalTextFormatter : ITextFormatter
 {
     /// <summary>
-    /// Used to determine if any items have been added to the JSON, yet.
+    /// The delimiter used to start events 2+.
     /// </summary>
-    private bool hasTags;
+    private string delimStart = string.Empty;
 
     /// <summary>
     /// Gets or sets a value indicating whether the message is rendered into JSON.
@@ -111,7 +111,7 @@ public class NormalTextFormatter : ITextFormatter
     {
         try
         {
-            hasTags = false; // force reset
+            delimStart = string.Empty; // force reset
 
             var buffer = new StringWriter();
             FormatContent(logEvent, buffer);
@@ -133,16 +133,13 @@ public class NormalTextFormatter : ITextFormatter
     /// <param name="output">The output.</param>
     protected void Write(string key, string value, TextWriter output)
     {
-        if (hasTags)
-        {
-            output.Write(',');
-        }
+        output.Write(delimStart);
 
         JsonValueFormatter.WriteQuotedJsonString(key, output);
         output.Write(":");
         JsonValueFormatter.WriteQuotedJsonString(value, output);
 
-        hasTags = true;
+        delimStart = ",";
     }
 
     private void FormatContent(LogEvent logEvent, TextWriter output)

--- a/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
+++ b/src/Serilog.Sinks.Http/Sinks/Http/TextFormatters/NormalTextFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 Serilog Contributors
+﻿// Copyright 2015-2025 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -267,9 +267,10 @@ public class NormalTextFormatter : ITextFormatter
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"");
-        output.Write(PropertiesKey);
-        output.Write("\":{");
+        output.Write(DELIMITER);
+        JsonValueFormatter.WriteQuotedJsonString(PropertiesKey, output);
+        output.Write(SEPARATOR);
+        output.Write("{");
 
         WritePropertiesValues(properties, output);
 
@@ -291,7 +292,7 @@ public class NormalTextFormatter : ITextFormatter
         foreach (var property in properties)
         {
             output.Write(precedingDelimiter);
-            precedingDelimiter = ",";
+            precedingDelimiter = DELIMITER;
 
             WritePropertyValue(property.Key, property.Value, output);
         }
@@ -309,7 +310,7 @@ public class NormalTextFormatter : ITextFormatter
         TextWriter output)
     {
         JsonValueFormatter.WriteQuotedJsonString(key, output);
-        output.Write(':');
+        output.Write(SEPARATOR);
         ValueFormatter.Instance.Format(value, output);
     }
 
@@ -346,36 +347,35 @@ public class NormalTextFormatter : ITextFormatter
         IReadOnlyDictionary<string, LogEventPropertyValue> properties,
         TextWriter output)
     {
-        output.Write(",\"");
-        output.Write(RenderingsKey);
-        output.Write("\":{");
+        output.Write(DELIMITER);
+        JsonValueFormatter.WriteQuotedJsonString(RenderingsKey, output);
+        output.Write(SEPARATOR);
+        output.Write("{");
 
         var rdelim = string.Empty;
         foreach (var ptoken in tokensGrouped)
         {
             output.Write(rdelim);
-            rdelim = ",";
+            rdelim = DELIMITER;
 
             JsonValueFormatter.WriteQuotedJsonString(ptoken.Key, output);
-            output.Write(":[");
+            output.Write(SEPARATOR);
+            output.Write("[");
 
             var fdelim = string.Empty;
             foreach (var format in ptoken)
             {
                 output.Write(fdelim);
-                fdelim = ",";
+                fdelim = DELIMITER;
 
-                output.Write("{\"");
-                output.Write(RenderingsFormatKey);
-                output.Write("\":");
-                JsonValueFormatter.WriteQuotedJsonString(format.Format ?? "\"\"", output);
-
-                output.Write(",\"");
-                output.Write(RenderingsRenderingKey);
-                output.Write("\":");
                 var sw = new StringWriter();
                 format.Render(properties, sw);
-                JsonValueFormatter.WriteQuotedJsonString(sw.ToString(), output);
+
+                output.Write("{");
+
+                Write(RenderingsFormatKey, format.Format ?? "\"\"", output, delimStart: string.Empty);
+                Write(RenderingsRenderingKey, sw.ToString(), output);
+
                 output.Write('}');
             }
 

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/FileSizeRolledBufferFilesShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/FileSizeRolledBufferFilesShould.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Serilog.Sinks.Http.Private.IO;
@@ -7,6 +9,24 @@ using Shouldly;
 using Xunit;
 
 namespace Serilog.Sinks.Http.Private.Durable;
+
+public class BookmarkFileNameData : IEnumerable<object[]>
+{
+    private readonly List<object[]> _data =
+    [
+        ["SomeBuffer", Path.Combine("{CurrentDirectory}", "SomeBuffer.bookmark")],
+        [Path.Combine(".", "SomeBuffer"), Path.Combine("{CurrentDirectory}", "SomeBuffer.bookmark")],
+        [Path.Combine("Folder", "SomeBuffer"), Path.Combine("{CurrentDirectory}", "Folder", "SomeBuffer.bookmark")],
+        [Path.Combine(".", "Folder", "SomeBuffer"), Path.Combine("{CurrentDirectory}", "Folder", "SomeBuffer.bookmark")],
+        [Path.Combine("..", "Folder", "SomeBuffer"), Path.Combine("{CurrentDirectory}", "..", "Folder", "SomeBuffer.bookmark")],
+        [Path.Combine(".", "..", "Folder", "SomeBuffer"), Path.Combine("{CurrentDirectory}", "..", "Folder", "SomeBuffer.bookmark")],
+        [Path.Combine("C:", "SomeBuffer"), Path.Combine("C:", "SomeBuffer.bookmark")],
+        [Path.Combine("C:", "Folder", "SomeBuffer"), Path.Combine("C:", "Folder", "SomeBuffer.bookmark")],
+    ];
+
+    public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
 
 public class FileSizeRolledBufferFilesShould
 {
@@ -18,14 +38,7 @@ public class FileSizeRolledBufferFilesShould
     }
 
     [Theory]
-    [InlineData("SomeBuffer", @"{CurrentDirectory}\SomeBuffer.bookmark")]
-    [InlineData(@".\SomeBuffer", @"{CurrentDirectory}\SomeBuffer.bookmark")]
-    [InlineData(@"Folder\SomeBuffer", @"{CurrentDirectory}\Folder\SomeBuffer.bookmark")]
-    [InlineData(@".\Folder\SomeBuffer", @"{CurrentDirectory}\Folder\SomeBuffer.bookmark")]
-    [InlineData(@"..\Folder\SomeBuffer", @"{CurrentDirectory}\..\Folder\SomeBuffer.bookmark")]
-    [InlineData(@".\..\Folder\SomeBuffer", @"{CurrentDirectory}\..\Folder\SomeBuffer.bookmark")]
-    [InlineData(@"C:\SomeBuffer", @"C:\SomeBuffer.bookmark")]
-    [InlineData(@"C:\Folder\SomeBuffer", @"C:\Folder\SomeBuffer.bookmark")]
+    [ClassData(typeof(BookmarkFileNameData))]
     public void HaveBookmarkFileName(string bufferBaseFilePath, string want)
     {
         // Arrange
@@ -241,7 +254,8 @@ public class FileSizeRolledBufferFilesShould
         {
             // "json" extension was used < v8
             "SomeBuffer-20001020_9999.json",
-            "SomeBuffer-20001020_10000.json",
+
+           "SomeBuffer-20001020_10000.json",
             "SomeBuffer-20001020_10001.json",
             // "txt" is used from >= v8
             "SomeBuffer-20001020_001.txt",

--- a/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/TimeRolledBufferFilesShould.cs
+++ b/test/Serilog.Sinks.HttpTests/Sinks/Http/Private/Durable/TimeRolledBufferFilesShould.cs
@@ -18,14 +18,7 @@ public class TimeRolledBufferFilesShould
     }
 
     [Theory]
-    [InlineData("SomeBuffer", @"{CurrentDirectory}\SomeBuffer.bookmark")]
-    [InlineData(@".\SomeBuffer", @"{CurrentDirectory}\SomeBuffer.bookmark")]
-    [InlineData(@"Folder\SomeBuffer", @"{CurrentDirectory}\Folder\SomeBuffer.bookmark")]
-    [InlineData(@".\Folder\SomeBuffer", @"{CurrentDirectory}\Folder\SomeBuffer.bookmark")]
-    [InlineData(@"..\Folder\SomeBuffer", @"{CurrentDirectory}\..\Folder\SomeBuffer.bookmark")]
-    [InlineData(@".\..\Folder\SomeBuffer", @"{CurrentDirectory}\..\Folder\SomeBuffer.bookmark")]
-    [InlineData(@"C:\SomeBuffer", @"C:\SomeBuffer.bookmark")]
-    [InlineData(@"C:\Folder\SomeBuffer", @"C:\Folder\SomeBuffer.bookmark")]
+    [ClassData(typeof(BookmarkFileNameData))]
     public void HaveBookmarkFileName(string bufferBaseFilePath, string want)
     {
         // Arrange


### PR DESCRIPTION
# Description

Updates the `NormalTextFormatter` implementation to use an inline setting of the starting delimiter instead of a member variable. This caused issues where the formatter was called in multiple threads while processing another instance. This had the effect of adding or neglecting a delimiter and generating invalid JSON.

Also, there was a change to output the JSON on a single line via the formatter. This caused issues with the internal File Sinks as they expect a single log entry per line. To be backward compatible, this creates a `FileTextFormatter` that will add newlines to the end of the internal formatter.

Finally, this adds constant fields for the delimiter and separator.